### PR TITLE
Bump qs from 6.5.2 to 6.5.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5165,9 +5165,9 @@ qs@6.7.0:
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 qs@~6.5.2:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
-  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 range-parser@~1.2.1:
   version "1.2.1"


### PR DESCRIPTION
### Description

In this pull request, the version of the `qs` package in the `yarn.lock` file has been updated from 6.5.2 to 6.5.3.

Summary of changes:
- Updated `qs` package from version 6.5.2 to 6.5.3 in the `yarn.lock` file.

These changes ensure that the project is utilizing the latest version of the `qs` package with the updated dependencies.