### PR TITLE
Bump bson from 1.1.1 to 1.1.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,9 +1419,9 @@ braces@^3.0.1:
     fill-range "^7.0.1"
 
 bson@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.1.tgz#4330f5e99104c4e751e7351859e2d408279f2f13"
-  integrity sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.6.tgz#fb819be9a60cd677e0853aee4ca712a785d6618a"
+  integrity sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==
 
 buffer-from@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
### Description

The changes in this pull request update the version of the "bson" package from 1.1.1 to 1.1.6 in the yarn.lock file.

- Update "bson" package from version 1.1.1 to 1.1.6.
- Update "resolved" URL for the "bson" package.
- Update the "integrity" property for the "bson" package.