### PR TITLE
Bump object-path from 0.11.4 to 0.11.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,9 +4652,9 @@ object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object-path@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
-  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
+  version "0.11.8"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.8.tgz#ed002c02bbdd0070b78a27455e8ae01fc14d4742"
+  integrity sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==
 
 object-visit@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description

In this pull request, the version of the `object-path` package in the `yarn.lock` file is being updated from `0.11.4` to `0.11.8`.

Changes:
- Update `object-path` package version in `yarn.lock` from `0.11.4` to `0.11.8`.
- Update the resolved URL for the `object-path` package.
- Update the integrity hash for the `object-path` package.