### PR TITLE
Bump decode-uri-component from 0.2.0 to 0.2.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,9 +2017,9 @@ decamelize@^1.2.0:
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 deep-extend@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
### Description

In this pull request, the `decode-uri-component` package in the `yarn.lock` file is being updated from version 0.2.0 to version 0.2.2.

Changes:
- Update `decode-uri-component` package version from 0.2.0 to 0.2.2.
- Update the resolved link for the `decode-uri-component` package.
- Update the integrity checksum for the `decode-uri-component` package.

These changes should ensure that the `decode-uri-component` package is using the updated version with the corresponding integrity and resolved links.